### PR TITLE
Update major version to 974

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ target/
 
 *.pyc
 
+Logs/*
+
 node_modules/
 
 *.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,14 @@ RUN  apt-get update \
 # Setup IB TWS
 RUN mkdir -p /opt/TWS
 WORKDIR /opt/TWS
-RUN wget -q http://one-algo.s3.amazonaws.com/ibgateway-latest-standalone-linux-x64-v972.1k.sh
-RUN chmod a+x ibgateway-latest-standalone-linux-x64-v972.1k.sh
+RUN wget -q http://cdn.quantconnect.com/interactive/ibgateway-latest-standalone-linux-x64-v974.4g.sh
+RUN chmod a+x ibgateway-latest-standalone-linux-x64-v974.4g.sh
 
 # Setup  IBController
-RUN mkdir -p /opt/IBController/
+RUN mkdir -p /opt/IBController/ && mkdir -p /root/IBController/Logs
 WORKDIR /opt/IBController/
-RUN wget -q http://one-algo.s3.amazonaws.com/IBController-QuantConnect-3.2.0.zip
-RUN unzip ./IBController-QuantConnect-3.2.0.zip
+RUN wget -q http://cdn.quantconnect.com/interactive/IBController-QuantConnect-3.2.0.5.zip
+RUN unzip ./IBController-QuantConnect-3.2.0.5.zip
 RUN chmod -R u+x *.sh && chmod -R u+x Scripts/*.sh
 
 # Install Java 8 TODO maybe just use "from:java8"
@@ -31,13 +31,14 @@ RUN \
   add-apt-repository -y ppa:webupd8team/java && \
   apt-get update && \
   apt-get install -y oracle-java8-installer && \
+  apt-get install -y dos2unix && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/cache/oracle-jdk8-installer
 
 WORKDIR /
 
 # Install TWS
-RUN yes n | /opt/TWS/ibgateway-latest-standalone-linux-x64-v972.1k.sh
+RUN yes n | /opt/TWS/ibgateway-latest-standalone-linux-x64-v974.4g.sh
 
 #CMD yes
 
@@ -52,8 +53,18 @@ ADD ./vnc/xvfb_init /etc/init.d/xvfb
 ADD ./vnc/vnc_init /etc/init.d/vnc
 ADD ./vnc/xvfb-daemon-run /usr/bin/xvfb-daemon-run
 
-RUN chmod -R u+x runscript.sh && chmod -R 777 /usr/bin/xvfb-daemon-run
-RUN chmod 777 /etc/init.d/xvfb
-RUN chmod 777 /etc/init.d/vnc
+RUN chmod -R u+x runscript.sh \
+  && chmod -R 777 /usr/bin/xvfb-daemon-run \
+  && chmod 777 /etc/init.d/xvfb \
+  && chmod 777 /etc/init.d/vnc
+
+RUN dos2unix /usr/bin/xvfb-daemon-run \
+  && dos2unix /etc/init.d/xvfb \
+  && dos2unix /etc/init.d/vnc \
+  && dos2unix runscript.sh
+
+# Below files copied during build to enable operation without volume mount
+COPY ./ib/IBController.ini /root/IBController/IBController.ini
+COPY ./ib/jts.ini /root/Jts/jts.ini
 
 CMD bash runscript.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - TZ=America/Chicago
       # Variables pulled from /IBController/IBControllerGatewayStart.sh
       - VNC_PASSWORD=1234 # CHANGEME
-      - TWS_MAJOR_VRSN=972
+      - TWS_MAJOR_VRSN=974
       - IBC_INI=/root/IBController/IBController.ini
       - IBC_PATH=/opt/IBController
       - TWS_PATH=/root/Jts

--- a/ib/IBController.ini
+++ b/ib/IBController.ini
@@ -5,7 +5,7 @@ FIX=no
 
 # IB API Authentication Settings
 # ------------------------------
-#IbLoginId=edemo
+#IbLoginId=fdemo
 #IbPassword=demouser
 PasswordEncrypted=no
 TradingMode=paper

--- a/ib/jts.ini
+++ b/ib/jts.ini
@@ -1,23 +1,27 @@
 [IBGateway]
 WriteDebug=false
 TrustedIPs=127.0.0.1
+RemoteHostOrderRouting=hdc1.ibllc.com
 MainWindow.Height=550
+RemotePortOrderRouting=4000
 ApiOnly=true
 LocalServerPort=4000
 MainWindow.Width=700
 
 [Logon]
 useRemoteSettings=false
+TimeZone=America/Chicago
 tradingMode=p
 colorPalletName=dark
-Steps=5
+Steps=6
 Locale=en
-UseSSL=true
 os_titlebar=false
-SupportsSSL=gdc1.ibllc.com:4000,true,20180722,false
+UseSSL=true
+SupportsSSL=gdc1.ibllc.com:4000,true,20190211,false
 s3store=true
 
 [Communication]
+SettingsDir=/root/Jts
 Peer=gdc1.ibllc.com:4001
 Region=hk
 


### PR DESCRIPTION
This branch updates the major version of IB Gateway to 974 from the QuantConnect builds.
Also included:
 - Logs folder added to .gitignore
 - Default Logs folder added to Dockerfile and mkdir
 - Dos2Unix added as helper for windows system usage
 - IBController.ini and jts.ini copied to image in Dockerfile to allow for volume-less running
 - Default user updated to `fdemo` (previously `edemo`)
 - jts.ini updated with new settings (apologies for the formatting update, this was done to fix line endings)