### PR TITLE
feat: update base image to Ubuntu 20.04 latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 LABEL maintainer="Mike Ehrenberg <mvberg@gmail.com>"
 
@@ -9,7 +9,7 @@ RUN  apt-get update \
   && apt-get install -y libxtst6 \
   && apt-get install -y libxrender1 \
   && apt-get install -y libxi6 \
-	&& apt-get install -y x11vnc \
+  && apt-get install -y x11vnc \
   && apt-get install -y socat \
   && apt-get install -y software-properties-common \
   && apt-get install -y dos2unix


### PR DESCRIPTION
Tested and working under Ubuntu focal fossa (20.04 LTS). We get the incremental performance upgrades from 16.04 to 20.04 from the packages and base distro.